### PR TITLE
Use default docker compose volumes for database.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,5 @@ services:
       POSTGRES_DB: typeormdb
       POSTGRES_USER: root
       POSTGRES_PASSWORD: onlyfordev
-    volumes:
-      - ./data/sql-data:/var/lib/postgresql/data
     ports:
       - "5432:5432"


### PR DESCRIPTION
Postgres requires root user permission for database data directory which causes permission problems when it's defined outside docker volumes folder in windows.
Default volumes should work for everyone.